### PR TITLE
Bumps versions update for AFox

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -41,13 +40,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
-    implementation "com.google.android.gms:play-services-wearable:17.0.0"
+    implementation "com.google.android.gms:play-services-wearable:17.1.0"
     implementation "androidx.percentlayout:percentlayout:1.0.0"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.palette:palette:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.palette:palette-ktx:1.0.0"
 
-    implementation "com.google.android.support:wearable:2.7.0"
-    compileOnly "com.google.android.wearable:wearable:2.7.0"
+    implementation "com.google.android.support:wearable:2.8.1"
+    compileOnly "com.google.android.wearable:wearable:2.8.1"
 }

--- a/base/src/main/AndroidManifest.xml
+++ b/base/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
         <service
             android:name=".AnalogDslWatchFace"
             android:label="@string/my_analog_name"
-            android:permission="android.permission.BIND_WALLPAPER">
+            android:permission="android.permission.BIND_WALLPAPER"
+            android:exported="true">
             <meta-data
                 android:name="android.service.wallpaper"
                 android:resource="@xml/watch_face" />

--- a/build.gradle
+++ b/build.gradle
@@ -23,17 +23,17 @@ buildscript {
         versionCode = 10002
 
         // SDK and tools
-        compileSdkVersion = 28
+        compileSdkVersion = 31
         minSdkVersion = 23
-        targetSdkVersion = 28
+        targetSdkVersion = 31
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
+        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -43,7 +43,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -41,13 +40,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
-    implementation "com.google.android.gms:play-services-wearable:17.0.0"
+    implementation "com.google.android.gms:play-services-wearable:17.1.0"
     implementation "androidx.percentlayout:percentlayout:1.0.0"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.palette:palette:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.palette:palette-ktx:1.0.0"
 
-    implementation "com.google.android.support:wearable:2.7.0"
-    compileOnly "com.google.android.wearable:wearable:2.7.0"
+    implementation "com.google.android.support:wearable:2.8.1"
+    compileOnly "com.google.android.wearable:wearable:2.8.1"
 }

--- a/complete/src/main/AndroidManifest.xml
+++ b/complete/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
         <service
             android:name=".AnalogDslWatchFace"
             android:label="@string/my_analog_name"
-            android:permission="android.permission.BIND_WALLPAPER">
+            android:permission="android.permission.BIND_WALLPAPER"
+            android:exported="true">
             <meta-data
                 android:name="android.service.wallpaper"
                 android:resource="@xml/watch_face" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Kotlin and Gradle versions updated
compileSdk and targetSdk versions updated
android:exported="true" in Manifest set
libraries version numbers updated
jcenter() replaced with mavenCentral()
apply plugin: 'kotlin-android-extensions'l ine removed
"org.jetbrains.kotlin:kotlin-stdlib-jdk7.." line removed